### PR TITLE
feat/fix: improve communication when engine cannot perform test

### DIFF
--- a/App/GlobalHandler/GlobalErrorHandler.go
+++ b/App/GlobalHandler/GlobalErrorHandler.go
@@ -71,9 +71,6 @@ func (e *ErrorHandler) RunSafe() {
 		if r := recover(); r != nil {
 			switch val := r.(type) {
 			case Errors.Error:
-				if val.Code >= 300 {
-
-				}
 				e.printError(val)
 			case HttpClient.HttpError:
 				// Convert specific HTTP error to generic App Error

--- a/App/GlobalHandler/GlobalErrorHandler.go
+++ b/App/GlobalHandler/GlobalErrorHandler.go
@@ -71,6 +71,9 @@ func (e *ErrorHandler) RunSafe() {
 		if r := recover(); r != nil {
 			switch val := r.(type) {
 			case Errors.Error:
+				if val.Code >= 300 {
+
+				}
 				e.printError(val)
 			case HttpClient.HttpError:
 				// Convert specific HTTP error to generic App Error

--- a/App/Reporter/CliReporter.go
+++ b/App/Reporter/CliReporter.go
@@ -146,16 +146,21 @@ func (c *cliReporter) StartListening() <-chan int {
 		// The loop terminates automatically when c.resultChannel is closed by the sender.
 		for result := range c.resultChannel {
 			ok, val := result.GetTestResult()
-			if !ok {
+			okInfo, info := result.GetReqInfo()
+			if !ok && !okInfo {
 				panic(Errors.Error{
 					Code: 100,
 					Message: `Cli Reporter error occurred. This could be due to:
-								- nil Test results`,
+								- fatal error`,
 					Source:      "Cli Reporter",
 					IsRetryable: false,
 				})
 			}
-			printTestResult(*val)
+			if okInfo {
+				printProcessInfo(*info)
+			} else {
+				printTestResult(*val)
+			}
 		}
 
 		// Signal completion. 0 indicates success (no upload errors in CLI mode).
@@ -198,5 +203,11 @@ func printTestResult(result Tests.TestResult) {
 	fmt.Printf("Certanity: %d\n", result.Certainty)
 	fmt.Printf("Threat level %v\n", result.ThreatLevel)
 	fmt.Printf("Description: %s\n", result.Description)
+	fmt.Println(separator)
+}
+
+func printProcessInfo(info strategy.RequestInfo) {
+	fmt.Printf("Engine was unable to test this website\n")
+	fmt.Printf("\nTest process message: \n%s\n", info.Message)
 	fmt.Println(separator)
 }

--- a/App/Reporter/backend_reporter.go
+++ b/App/Reporter/backend_reporter.go
@@ -18,6 +18,7 @@ package Reporter
 
 import (
 	"Engine-AntiGinx/App/Errors"
+	"Engine-AntiGinx/App/Reporter/types"
 	"Engine-AntiGinx/App/Tests"
 	"Engine-AntiGinx/App/execution/strategy"
 	"bytes"
@@ -150,6 +151,8 @@ func InitializeBackendReporter(channel chan strategy.ResultWrapper, backendURL s
 //	if failedCount > 0 {
 //	    log.Printf("Warning: %d results failed to upload", failedCount)
 //	}
+
+// TODO rozróżnić kiedy jeden z wyników na kanale ma jakieś reqInfo
 func (b *backendReporter) StartListening() <-chan int {
 	done := make(chan int)
 
@@ -172,7 +175,7 @@ func (b *backendReporter) StartListening() <-chan int {
 				if len(retryChan) == 0 {
 					if failedUploads == 0 {
 						b.sendLastWithFlag(
-							Tests.TestResultWrapper{
+							types.TestResultWrapper{
 								Target:  b.target,
 								TestId:  b.testId,
 								Result:  Tests.TestResult{},
@@ -191,6 +194,16 @@ func (b *backendReporter) StartListening() <-chan int {
 					// Setting the channel to nil disables this case in the select statement,
 					// allowing the loop to continue processing retries.
 					b.resultChannel = nil
+				} else if pres, info := res.GetReqInfo(); pres {
+					b.sendLastWithFlag(
+						types.TestResultWrapper{
+							Target:      b.target,
+							TestId:      b.testId,
+							Result:      Tests.TestResult{},
+							EndFlag:     false,
+							ResultType:  types.Message,
+							ProcessInfo: *info,
+						}, &failedUploads)
 				} else {
 					b.tryToSendOrEnqueue(res, 0, retryChan, &retryWg, &failedUploads)
 				}
@@ -239,11 +252,16 @@ func (b *backendReporter) tryToSendOrEnqueue(result strategy.ResultWrapper, attN
 		*failedUploads++
 		return
 	}
-	resultWrapper := Tests.TestResultWrapper{
-		Target:  b.target,
-		TestId:  b.testId,
-		Result:  *val,
-		EndFlag: false,
+	resultWrapper := types.TestResultWrapper{
+		Target:     b.target,
+		TestId:     b.testId,
+		Result:     *val,
+		EndFlag:    false,
+		ResultType: types.Success,
+		ProcessInfo: strategy.RequestInfo{
+			Message: "Test completed successfully",
+			Code:    0,
+		},
 	}
 	err := b.sendToBackend(resultWrapper)
 	if err == nil {
@@ -315,7 +333,7 @@ func (b *backendReporter) tryToSendOrEnqueue(result strategy.ResultWrapper, attN
 //	        // Permanent failure
 //	    }
 //	}
-func (b *backendReporter) sendToBackend(result Tests.TestResultWrapper) error {
+func (b *backendReporter) sendToBackend(result types.TestResultWrapper) error {
 	req, err := b.prepareReqWithErrHandling(result)
 	if err != nil {
 		return err
@@ -357,7 +375,7 @@ func (b *backendReporter) handleRetryLogic(response *http.Response) *Errors.Erro
 		IsRetryable: retryable,
 	}
 }
-func (b *backendReporter) prepareReqWithErrHandling(result Tests.TestResultWrapper) (*http.Request, *Errors.Error) {
+func (b *backendReporter) prepareReqWithErrHandling(result types.TestResultWrapper) (*http.Request, *Errors.Error) {
 	marshalled, err := json.Marshal(result)
 	if err != nil {
 		return nil, &Errors.Error{
@@ -392,7 +410,7 @@ func (b *backendReporter) prepareReqWithErrHandling(result Tests.TestResultWrapp
 // Parameters:
 //   - result:        The TestResultWrapper to send. Typically, this should be an empty result with EndFlag set to true.
 //   - failedUploads: Pointer to an integer counter tracking the number of failed uploads. This will be incremented if the final request fails.
-func (b *backendReporter) sendLastWithFlag(result Tests.TestResultWrapper, failedUploads *int) {
+func (b *backendReporter) sendLastWithFlag(result types.TestResultWrapper, failedUploads *int) {
 	err := b.sendToBackend(result)
 	if err == nil {
 		return

--- a/App/Reporter/backend_reporter_test.go
+++ b/App/Reporter/backend_reporter_test.go
@@ -30,7 +30,7 @@ func TestBackendReporter_StartListening(t *testing.T) {
 					ThreatLevel: 0,
 					Metadata:    nil,
 					Description: "",
-				}, nil),
+				}, nil, nil),
 		},
 		{
 			name:            "Error 500, retryable",
@@ -44,7 +44,7 @@ func TestBackendReporter_StartListening(t *testing.T) {
 					ThreatLevel: 0,
 					Metadata:    nil,
 					Description: "",
-				}, nil),
+				}, nil, nil),
 		},
 		{
 			name:            "Error 400, non retryable",
@@ -58,14 +58,25 @@ func TestBackendReporter_StartListening(t *testing.T) {
 					ThreatLevel: 0,
 					Metadata:    nil,
 					Description: "",
-				}, nil),
+				}, nil, nil),
 		},
 		{
 			name:            "Nil test results",
 			statusCode:      http.StatusOK,
 			expectedFailure: 1,
 			expectedCalls:   0,
-			testResult:      strategy.WrapStrategyResult(nil, nil),
+			testResult:      strategy.WrapStrategyResult(nil, nil, nil),
+		},
+		{
+			name:            "Unprocessed test with Request Info",
+			statusCode:      http.StatusOK,
+			expectedFailure: 0,
+			expectedCalls:   2,
+			testResult: strategy.WrapStrategyResult(
+				nil, nil, &strategy.RequestInfo{
+					Message: "Test message",
+					Code:    300,
+				}),
 		},
 	}
 	for _, tt := range tests {

--- a/App/Reporter/helpreporter_test.go
+++ b/App/Reporter/helpreporter_test.go
@@ -21,7 +21,7 @@ func prepareHelpData() strategy.ResultWrapper {
 	}
 	helpMess.AppendSection(helpSec)
 	helpMess.HelpHeader("test header")
-	return strategy.WrapStrategyResult(nil, &helpMess)
+	return strategy.WrapStrategyResult(nil, &helpMess, nil)
 }
 func TestHelpReporter_StartListening(t *testing.T) {
 	tests := []helpRepTest{

--- a/App/Reporter/types/Types.go
+++ b/App/Reporter/types/Types.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"Engine-AntiGinx/App/Tests"
+	"Engine-AntiGinx/App/execution/strategy"
+)
+
+type ResultType int
+
+const (
+	Message ResultType = iota
+	Success
+)
+
+// TestResultWrapper represents fully structured response sent to the backend
+// Fields:
+//   - Target: Given target
+//   - TestId: id related to full scan
+//   - Result: Core data of test
+//   - EndFlag: Check if engine finished its job
+type TestResultWrapper struct {
+	Target      string               `json:"target"`
+	TestId      string               `json:"testId"`
+	Result      Tests.TestResult     `json:"result"`
+	EndFlag     bool                 `json:"endFlag"`
+	ResultType  ResultType           `json:"resultType"`
+	ProcessInfo strategy.RequestInfo `json:"message"`
+}

--- a/App/Runner/jobrunner_test.go
+++ b/App/Runner/jobrunner_test.go
@@ -46,7 +46,7 @@ func (m *MockStrategy) Execute(ctx strategy.TestContext, channel chan strategy.R
 		Metadata:    nil,
 		Description: "Mock test",
 	}
-	channel <- strategy.WrapStrategyResult(&testResult, nil)
+	channel <- strategy.WrapStrategyResult(&testResult, nil, nil)
 }
 
 func (m *MockStrategy) GetName() string {

--- a/App/Tests/Types.go
+++ b/App/Tests/Types.go
@@ -70,19 +70,6 @@ type TestResult struct {
 	Description string      `json:"Description"` // Human-readable findings explanation
 }
 
-// TestResultWrapper represents fully structured response sent to the backend
-// Fields:
-//   - Target: Given target
-//   - TestId: id related to full scan
-//   - Result: Core data of test
-//   - EndFlag: Check if engine finished its job
-type TestResultWrapper struct {
-	Target  string     `json:"target"`
-	TestId  string     `json:"testId"`
-	Result  TestResult `json:"result"`
-	EndFlag bool       `json:"endFlag"`
-}
-
 // ResponseTestParams encapsulates the parameters passed to a ResponseTest for execution.
 // It provides the HTTP response object that tests analyze to detect security issues,
 // misconfigurations, and vulnerabilities.

--- a/App/execution/strategy/StrategyHelper.go
+++ b/App/execution/strategy/StrategyHelper.go
@@ -1,0 +1,130 @@
+package strategy
+
+import (
+	HttpClient "Engine-AntiGinx/App/HTTP"
+	"Engine-AntiGinx/App/Tests"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// LoadWebsiteContent fetches the target website content via HTTP GET request and returns
+// the response for sharing across all test executions. This function performs a single
+// HTTP request to avoid redundant network calls for each test.
+//
+// The function creates an HTTP client with custom headers to identify the scanner and
+// executes a GET request against the target URL. The returned response object is then
+// shared among all concurrent test goroutines.
+//
+// HTTP configuration:
+//   - User-Agent: "AntiGinx-TestClient/1.0" (identifies the scanner)
+//   - Method: GET
+//   - Timeout: Configured in HttpClient wrapper (default: 30 seconds)
+//
+// The function may panic with httpError if:
+//   - Request creation fails (code 100)
+//   - Network error occurs (code 101)
+//   - Non-200 status code returned (code 102)
+//   - Response body reading fails (code 200)
+//   - Bot protection detected (code 300)
+//
+// Parameters:
+//   - target: The fully qualified URL to request (e.g., "https://example.com")
+//
+// Returns:
+//   - *http.Response: Raw HTTP response object to be shared across all tests
+//
+// Example:
+//
+//	response := loadWebsiteContent("https://example.com", true)
+//	// Response contains headers, body, status code, etc.
+//	// This single response is analyzed by all tests
+func LoadWebsiteContent(target string, useAntiBotDetection bool) (*http.Response, *RequestInfo) {
+	opts := []HttpClient.WrapperOption{
+		HttpClient.WithHeaders(map[string]string{
+			"User-Agent": "AntiGinx-TestClient/1.0",
+		}),
+	}
+	if useAntiBotDetection {
+		opts = append(opts, HttpClient.WithAntiBotDetection())
+	}
+	httpClient := HttpClient.CreateHttpWrapper(opts...)
+	var content *http.Response
+	var reqInfo *RequestInfo
+
+	for i := 0; i < 2; i++ {
+		panicTriggerred := false
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicTriggerred = true
+					switch val := r.(type) {
+					case HttpClient.HttpError:
+						reqInfo = &RequestInfo{
+							Message: val.Message,
+							Code:    val.Code,
+						}
+						if !val.IsRetryable {
+							return
+						}
+					default:
+						reqInfo = &RequestInfo{
+							Message: "Unknown error occurred",
+							Code:    999,
+						}
+					}
+				}
+			}()
+			content = httpClient.Get(target)
+		}()
+		if !panicTriggerred {
+			return content, &RequestInfo{
+				Message: "Content loaded successfully",
+				Code:    0,
+			}
+		}
+		if i < 1 {
+			time.Sleep(time.Second * 2)
+		}
+	}
+	return nil, reqInfo
+}
+
+// PerformTest executes a single security test in a separate goroutine and publishes
+// the result to the shared results channel. This function is designed to be called
+// as a goroutine and implements the worker pattern for concurrent test execution.
+//
+// Workflow:
+//  1. Wrap HTTP response in ResponseTestParams structure
+//  2. Execute the test's Run method with the parameters
+//  3. Send the TestResult to the results channel
+//  4. Signal completion via WaitGroup (deferred)
+//
+// The function uses defer wg.Done() to ensure the WaitGroup is always decremented,
+// even if the test panics or encounters an error. This guarantees proper synchronization
+// and prevents deadlocks in the orchestration logic.
+//
+// Concurrency considerations:
+//   - Thread-safe: Multiple goroutines can call this function concurrently
+//   - Shared response: All tests receive the same HTTP response object (read-only)
+//   - Channel communication: Results are sent to buffered channel (non-blocking)
+//   - Synchronization: WaitGroup ensures proper cleanup
+//
+// Parameters:
+//   - test: Pointer to the ResponseTest to execute
+//   - wg: WaitGroup for synchronizing test completion
+//   - results: Send-only channel for publishing test results
+//   - response: Shared HTTP response object to analyze
+//
+// Example usage (called by Orchestrate):
+//
+//	wg.Add(1)
+//	go performTest(httpsTest, &wg, resultChannel, httpResponse)
+//	// Test runs concurrently, result sent to channel, WaitGroup decremented
+func PerformTest(test *Tests.ResponseTest, wg *sync.WaitGroup, results chan<- ResultWrapper, response *http.Response) {
+	defer wg.Done()
+	testParams := Tests.ResponseTestParams{Response: response}
+	testResult := test.Run(testParams)
+	wrapped := WrapStrategyResult(&testResult, nil, nil)
+	results <- wrapped
+}

--- a/App/execution/strategy/Types.go
+++ b/App/execution/strategy/Types.go
@@ -1,6 +1,13 @@
 package strategy
 
-import "Engine-AntiGinx/App/Tests"
+import (
+	"Engine-AntiGinx/App/Tests"
+)
+
+type RequestInfo struct {
+	Message string `json:"Message"`
+	Code    int    `json:"Code"`
+}
 
 // ResultWrapper encapsulates the outcome of a strategy execution.
 //
@@ -9,6 +16,7 @@ import "Engine-AntiGinx/App/Tests"
 // and help/usage information (e.g., manual pages) using a single data structure.
 type ResultWrapper struct {
 	testResult  *Tests.TestResult
+	reqInfo     *RequestInfo
 	helpMessage *HelpStrategyResult
 }
 
@@ -38,10 +46,11 @@ type HelpSection struct {
 //
 // Returns:
 //   - ResultWrapper: The initialized wrapper struct
-func WrapStrategyResult(testResult *Tests.TestResult, helpMessage *HelpStrategyResult) ResultWrapper {
+func WrapStrategyResult(testResult *Tests.TestResult, helpMessage *HelpStrategyResult, info *RequestInfo) ResultWrapper {
 	return ResultWrapper{
 		testResult:  testResult,
 		helpMessage: helpMessage,
+		reqInfo:     info,
 	}
 }
 
@@ -54,6 +63,10 @@ func WrapStrategyResult(testResult *Tests.TestResult, helpMessage *HelpStrategyR
 //   - *Tests.TestResult: The pointer to the test result (or nil)
 func (w ResultWrapper) GetTestResult() (bool, *Tests.TestResult) {
 	return w.testResult != nil, w.testResult
+}
+
+func (w ResultWrapper) GetReqInfo() (bool, *RequestInfo) {
+	return w.reqInfo != nil, w.reqInfo
 }
 
 // GetHelpMessage retrieves the underlying help strategy result from the wrapper.

--- a/App/execution/strategy/strategyImpl/alltests.go
+++ b/App/execution/strategy/strategyImpl/alltests.go
@@ -16,11 +16,16 @@ func InitializeAllTestsStrategy() *allTestsStrategy {
 func (a *allTestsStrategy) Execute(ctx strategy.TestContext, channel chan strategy.ResultWrapper, wg *sync.WaitGroup, antiBotFlag bool) {
 	targetFormatter := helpers.InitializeTargetFormatter()
 	target := targetFormatter.Format(ctx.Target, ctx.Args)
-	result := loadWebsiteContent(*target, antiBotFlag)
+	result, reqInfo := strategy.LoadWebsiteContent(*target, antiBotFlag)
+
+	if reqInfo.Code != 0 {
+		channel <- strategy.WrapStrategyResult(nil, nil, reqInfo)
+		return
+	}
 
 	for _, val := range Registry.GetAllTests() {
 		wg.Add(1)
-		go performTest(val, wg, channel, result)
+		go strategy.PerformTest(val, wg, channel, result)
 	}
 }
 

--- a/App/execution/strategy/strategyImpl/generalhelp.go
+++ b/App/execution/strategy/strategyImpl/generalhelp.go
@@ -58,7 +58,7 @@ func (s *generalHelpStrategy) Execute(ctx strategy.TestContext, channel chan str
 		helpMess := strategy.HelpStrategyResult{}
 		helpMess.AppendSection(sectionsArr)
 		helpMess.HelpHeader(name)
-		result := strategy.WrapStrategyResult(nil, &helpMess)
+		result := strategy.WrapStrategyResult(nil, &helpMess, nil)
 		channel <- result
 	}()
 }

--- a/App/execution/strategy/strategyImpl/header_test._strategy.go
+++ b/App/execution/strategy/strategyImpl/header_test._strategy.go
@@ -2,15 +2,11 @@ package strategyImpl
 
 import (
 	error "Engine-AntiGinx/App/Errors"
-	HttpClient "Engine-AntiGinx/App/HTTP"
 	"Engine-AntiGinx/App/Helpers"
 	"Engine-AntiGinx/App/Registry"
-	"Engine-AntiGinx/App/Tests"
 	"Engine-AntiGinx/App/execution/strategy"
 	"fmt"
-	"net/http"
 	"sync"
-	"time"
 )
 
 // headerTestStrategy implements the strategy.TestStrategy interface.
@@ -46,7 +42,12 @@ func (h *headerTestStrategy) Execute(ctx strategy.TestContext, channel chan stra
 	// Using target formatter to properly build target URL
 	targetFormatter := helpers.InitializeTargetFormatter()
 	target := targetFormatter.Format(ctx.Target, ctx.Args)
-	result := loadWebsiteContent(*target, antiBotFlag)
+	result, reqInfo := strategy.LoadWebsiteContent(*target, antiBotFlag)
+
+	if reqInfo.Code != 0 {
+		channel <- strategy.WrapStrategyResult(nil, nil, reqInfo)
+		return
+	}
 
 	for _, val := range ctx.Args {
 		t, ok := Registry.GetTest(val)
@@ -64,7 +65,7 @@ func (h *headerTestStrategy) Execute(ctx strategy.TestContext, channel chan stra
 		wg.Add(1)
 
 		// Launch the test asynchronously.
-		go performTest(t, wg, channel, result)
+		go strategy.PerformTest(t, wg, channel, result)
 
 	}
 }
@@ -84,116 +85,4 @@ func (h *headerTestStrategy) GetName() string {
 // consistent as more reporter types are introduced.
 func (h *headerTestStrategy) GetPreferredReporterType() strategy.ReporterType {
 	return strategy.CLIReporter
-}
-
-// loadWebsiteContent fetches the target website content via HTTP GET request and returns
-// the response for sharing across all test executions. This function performs a single
-// HTTP request to avoid redundant network calls for each test.
-//
-// The function creates an HTTP client with custom headers to identify the scanner and
-// executes a GET request against the target URL. The returned response object is then
-// shared among all concurrent test goroutines.
-//
-// HTTP configuration:
-//   - User-Agent: "AntiGinx-TestClient/1.0" (identifies the scanner)
-//   - Method: GET
-//   - Timeout: Configured in HttpClient wrapper (default: 30 seconds)
-//
-// The function may panic with httpError if:
-//   - Request creation fails (code 100)
-//   - Network error occurs (code 101)
-//   - Non-200 status code returned (code 102)
-//   - Response body reading fails (code 200)
-//   - Bot protection detected (code 300)
-//
-// Parameters:
-//   - target: The fully qualified URL to request (e.g., "https://example.com")
-//
-// Returns:
-//   - *http.Response: Raw HTTP response object to be shared across all tests
-//
-// Example:
-//
-//	response := loadWebsiteContent("https://example.com", true)
-//	// Response contains headers, body, status code, etc.
-//	// This single response is analyzed by all tests
-func loadWebsiteContent(target string, useAntiBotDetection bool) *http.Response {
-	opts := []HttpClient.WrapperOption{
-		HttpClient.WithHeaders(map[string]string{
-			"User-Agent": "AntiGinx-TestClient/1.0",
-		}),
-	}
-	if useAntiBotDetection {
-		opts = append(opts, HttpClient.WithAntiBotDetection())
-	}
-	httpClient := HttpClient.CreateHttpWrapper(opts...)
-	var content *http.Response
-	var lastErr HttpClient.HttpError
-
-	for i := 0; i < 2; i++ {
-		panicTriggerred := false
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					panicTriggerred = true
-					switch val := r.(type) {
-					case HttpClient.HttpError:
-						if !val.IsRetryable {
-							panic(val)
-						}
-						lastErr = val
-					default:
-						panic(r)
-					}
-				}
-			}()
-			content = httpClient.Get(target)
-		}()
-		if !panicTriggerred {
-			return content
-		}
-		if i < 1 {
-			time.Sleep(time.Second * 2)
-		}
-	}
-	panic(lastErr)
-}
-
-// performTest executes a single security test in a separate goroutine and publishes
-// the result to the shared results channel. This function is designed to be called
-// as a goroutine and implements the worker pattern for concurrent test execution.
-//
-// Workflow:
-//  1. Wrap HTTP response in ResponseTestParams structure
-//  2. Execute the test's Run method with the parameters
-//  3. Send the TestResult to the results channel
-//  4. Signal completion via WaitGroup (deferred)
-//
-// The function uses defer wg.Done() to ensure the WaitGroup is always decremented,
-// even if the test panics or encounters an error. This guarantees proper synchronization
-// and prevents deadlocks in the orchestration logic.
-//
-// Concurrency considerations:
-//   - Thread-safe: Multiple goroutines can call this function concurrently
-//   - Shared response: All tests receive the same HTTP response object (read-only)
-//   - Channel communication: Results are sent to buffered channel (non-blocking)
-//   - Synchronization: WaitGroup ensures proper cleanup
-//
-// Parameters:
-//   - test: Pointer to the ResponseTest to execute
-//   - wg: WaitGroup for synchronizing test completion
-//   - results: Send-only channel for publishing test results
-//   - response: Shared HTTP response object to analyze
-//
-// Example usage (called by Orchestrate):
-//
-//	wg.Add(1)
-//	go performTest(httpsTest, &wg, resultChannel, httpResponse)
-//	// Test runs concurrently, result sent to channel, WaitGroup decremented
-func performTest(test *Tests.ResponseTest, wg *sync.WaitGroup, results chan<- strategy.ResultWrapper, response *http.Response) {
-	defer wg.Done()
-	testParams := Tests.ResponseTestParams{Response: response}
-	testResult := test.Run(testParams)
-	wrapped := strategy.WrapStrategyResult(&testResult, nil)
-	results <- wrapped
 }

--- a/App/execution/strategy/strategyImpl/headertesthelp.go
+++ b/App/execution/strategy/strategyImpl/headertesthelp.go
@@ -56,7 +56,7 @@ func (h *headerTestHelp) Execute(ctx strategy.TestContext, channel chan strategy
 		helpMess := strategy.HelpStrategyResult{}
 		helpMess.AppendSection(description)
 		helpMess.HelpHeader(header)
-		res := strategy.WrapStrategyResult(nil, &helpMess)
+		res := strategy.WrapStrategyResult(nil, &helpMess, nil)
 		channel <- res
 	}()
 }


### PR DESCRIPTION
Added ReqInfo to TestResultWrapper. Now engine gives feedback why the test cannot be performed. For example when there is antiBot challenges like Captcha